### PR TITLE
feat: add theme setting with SharedPreferences for light/dark mode

### DIFF
--- a/lib/core/common/strings.dart
+++ b/lib/core/common/strings.dart
@@ -15,7 +15,8 @@ class Strings {
   static String githubUrl = 'https://github.com/waffiqaziz/restaurantzz';
 
   static String searchAnyRestaurant = "Search any restaurant...";
-  static String noResult = "No results founds";
+  static String noResult =
+      "We can't found any restaurant.\nMaybe a little mistake?";
 
   static String reviews = "Reviews";
   static String seeReviews = "See Reviews";
@@ -28,4 +29,11 @@ class Strings {
   static String submitReviewSuccess = "Review submitted successfully!";
 
   static String yourFavorite = "Your Favorite";
+  static String noFavorite =
+      "We cannot find restaurant you are looking for,\nmaybe add favorite first";
+
+  static String sorry = "SORRY";
+  static String settings = "Settings";
+  static String enableNotification = "Enable Notification";
+  static String darkMode = "Dark Mode";
 }

--- a/lib/core/data/model/setting.dart
+++ b/lib/core/data/model/setting.dart
@@ -1,0 +1,9 @@
+class Setting {
+  final bool notificationEnable;
+  final bool isDark;
+
+  Setting({
+    required this.notificationEnable,
+    required this.isDark,
+  });
+}

--- a/lib/core/data/services/shared_preferences.dart
+++ b/lib/core/data/services/shared_preferences.dart
@@ -1,0 +1,39 @@
+import 'package:restaurantzz/core/data/model/setting.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SharedPreferencesService {
+  final SharedPreferences _preferences;
+
+  SharedPreferencesService(this._preferences);
+
+  static const String keyNotification = "RESTAURANTZZ_NOTIFICATION";
+  static const String keyIsDark = "RESTAURANTZZ_DARK_MODE";
+
+  Future<void> saveSettingValue(Setting setting) async {
+    try {
+      await _preferences.setBool(keyNotification, setting.notificationEnable);
+      await _preferences.setBool(keyIsDark, setting.isDark);
+    } catch (e) {
+      throw Exception("Shared preferences cannot save the setting value.");
+    }
+  }
+
+  Future<void> setTheme(bool isDark) async {
+    try {
+      await _preferences.setBool(keyIsDark, isDark);
+    } catch (e) {
+      throw Exception("Failed setting theme.");
+    }
+  }
+
+  Setting getSettingValue() {
+    return Setting(
+      notificationEnable: _preferences.getBool(keyNotification) ?? false,
+      isDark: _preferences.getBool(keyIsDark) ?? true,
+    );
+  }
+
+  bool isDarkModeSet() {
+    return _preferences.containsKey(keyIsDark);
+  }
+}

--- a/lib/core/provider/setting/shared_preferences_provider.dart
+++ b/lib/core/provider/setting/shared_preferences_provider.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:restaurantzz/core/data/model/setting.dart';
+import 'package:restaurantzz/core/data/services/shared_preferences.dart';
+
+class SharedPreferencesProvider extends ChangeNotifier {
+  final SharedPreferencesService _service;
+
+  String _message = "";
+  String get message => _message;
+
+  Setting? _setting;
+  Setting? get setting => _setting;
+
+  SharedPreferencesProvider(this._service) {
+    _initializeSettings();
+  }
+
+  void _initializeSettings() {
+    try {
+      final savedSetting = _service.getSettingValue();
+
+      final isDarkSystem =
+          WidgetsBinding.instance.platformDispatcher.platformBrightness ==
+              Brightness.dark;
+      _setting = Setting(
+        notificationEnable: savedSetting.notificationEnable,
+        isDark: _service.isDarkModeSet() ? savedSetting.isDark : isDarkSystem,
+      );
+      _message = "Settings initialized successfully";
+    } catch (e) {
+      _message = "Failed to initialize settings";
+    }
+    notifyListeners();
+  }
+
+  Future<void> saveSettingValue(Setting value) async {
+    try {
+      await _service.saveSettingValue(value);
+      _setting = value;
+      _message = "Your data is saved";
+    } catch (e) {
+      _message = "Failed to save your data";
+    }
+    notifyListeners();
+  }
+
+  Future<void> setTheme(bool isDark) async {
+    try {
+      await _service.setTheme(isDark);
+      _setting = Setting(
+        notificationEnable: _setting!.notificationEnable,
+        isDark: isDark,
+      );
+      _message = "Theme successfully updated.";
+    } catch (e) {
+      _message = "Failed to update theme. Please try again.";
+    }
+    notifyListeners();
+  }
+
+  void getSettingValue() {
+    try {
+      _setting = _service.getSettingValue();
+      _message = "Data successfully retrieved";
+    } catch (e) {
+      _message = "Failed to get your data";
+    }
+    notifyListeners();
+  }
+}

--- a/lib/feature/main/screen/main_screen.dart
+++ b/lib/feature/main/screen/main_screen.dart
@@ -5,6 +5,7 @@ import 'package:restaurantzz/core/provider/main/index_nav_provider.dart';
 import 'package:restaurantzz/feature/favorite/screen/favorite_screen.dart';
 import 'package:restaurantzz/feature/list/screen/list_screen.dart';
 import 'package:restaurantzz/feature/search/screen/search_screen.dart';
+import 'package:restaurantzz/feature/settings/screen/settings_screen.dart';
 
 class MainScreen extends StatelessWidget {
   const MainScreen({super.key});
@@ -20,6 +21,7 @@ class MainScreen extends StatelessWidget {
               ListScreen(),
               SearchScreen(),
               FavoriteScreen(),
+              SettingsScreen(),
             ],
           );
         },
@@ -44,6 +46,11 @@ class MainScreen extends StatelessWidget {
             icon: const Icon(Icons.favorite_outline_rounded),
             label: Strings.favorite,
             tooltip: Strings.favorite,
+          ),
+          NavigationDestination(
+            icon: const Icon(Icons.settings),
+            label: Strings.settings,
+            tooltip: Strings.settings,
           ),
         ],
       ),

--- a/lib/feature/settings/screen/settings_screen.dart
+++ b/lib/feature/settings/screen/settings_screen.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:restaurantzz/core/common/strings.dart';
+import 'package:restaurantzz/core/data/model/setting.dart';
+import 'package:restaurantzz/core/provider/setting/shared_preferences_provider.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<SharedPreferencesProvider>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          Strings.settings,
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+        ),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: [
+            // notification switch
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    const Icon(Icons.notifications_active_rounded),
+                    const SizedBox(width: 8),
+                    Text(
+                      Strings.enableNotification,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                  ],
+                ),
+                Switch(
+                  value: provider.setting?.notificationEnable ?? true,
+                  onChanged: (bool value) {
+                    final updatedSetting = Setting(
+                      notificationEnable: value,
+                      isDark: provider.setting?.isDark ?? false,
+                    );
+                    provider.saveSettingValue(updatedSetting);
+                  },
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+
+            // dark mode switch
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  children: [
+                    const Icon(Icons.dark_mode_rounded),
+                    const SizedBox(width: 8),
+                    Text(
+                      Strings.darkMode,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                  ],
+                ),
+                Switch(
+                  value: provider.setting?.isDark ?? false,
+                  onChanged: (bool value) {
+                    provider.setTheme(value);
+                  },
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+
+            // Status Message
+            Text(
+              provider.message,
+              style: const TextStyle(color: Colors.grey),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,20 +2,25 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:restaurantzz/core/common/strings.dart';
 import 'package:restaurantzz/core/data/local/local_database_service.dart';
+import 'package:restaurantzz/core/data/services/shared_preferences.dart';
 import 'package:restaurantzz/core/networking/services/api_services.dart';
 import 'package:restaurantzz/core/provider/detail/detail_provider.dart';
 import 'package:restaurantzz/core/provider/favorite/local_database_provider.dart';
 import 'package:restaurantzz/core/provider/list/list_provider.dart';
 import 'package:restaurantzz/core/provider/main/index_nav_provider.dart';
 import 'package:restaurantzz/core/provider/search/search_provider.dart';
+import 'package:restaurantzz/core/provider/setting/shared_preferences_provider.dart';
 import 'package:restaurantzz/core/theme/restaurantzz_theme.dart';
 import 'package:restaurantzz/core/theme/util.dart';
 import 'package:restaurantzz/feature/detail/screen/detail_screen.dart';
 import 'package:restaurantzz/feature/main/screen/main_screen.dart';
 import 'package:restaurantzz/static/navigation_route.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-void main() {
+void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await SharedPreferences.getInstance();
+
   runApp(
     MultiProvider(
       providers: [
@@ -48,6 +53,14 @@ void main() {
             context.read<LocalDatabaseService>(),
           ),
         ),
+        Provider(
+          create: (context) => SharedPreferencesService(prefs),
+        ),
+        ChangeNotifierProvider(
+          create: (context) => SharedPreferencesProvider(
+            context.read<SharedPreferencesService>(),
+          ),
+        ),
       ],
       child: const MyApp(),
     ),
@@ -60,28 +73,35 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     TextTheme textTheme = createTextTheme(context);
-
     RestaurantzzTheme theme = RestaurantzzTheme(textTheme);
-    return MaterialApp(
-      title: Strings.restaurantzz,
-      theme: theme.light(),
-      darkTheme: theme.dark(),
-      initialRoute: NavigationRoute.mainRoute.name,
-      onGenerateRoute: (settings) {
-        switch (settings.name) {
-          case '/':
-            return MaterialPageRoute(builder: (_) => const MainScreen());
-          case '/detail':
-            final args = settings.arguments as Map<String, String>;
-            return MaterialPageRoute(
-              builder: (_) => DetailScreen(
-                restaurantId: args['restaurantId']!,
-                heroTag: args['heroTag']!,
-              ),
-            );
-          default:
-            return null; // Handle unknown routes if needed
-        }
+
+    return Consumer<SharedPreferencesProvider>(
+      builder: (context, provider, child) {
+        final isDarkMode = provider.setting?.isDark ?? false;
+
+        return MaterialApp(
+          title: Strings.restaurantzz,
+          theme: theme.light(),
+          darkTheme: theme.dark(),
+          themeMode: isDarkMode ? ThemeMode.dark : ThemeMode.light,
+          initialRoute: NavigationRoute.mainRoute.name,
+          onGenerateRoute: (settings) {
+            switch (settings.name) {
+              case '/':
+                return MaterialPageRoute(builder: (_) => const MainScreen());
+              case '/detail':
+                final args = settings.arguments as Map<String, String>;
+                return MaterialPageRoute(
+                  builder: (_) => DetailScreen(
+                    restaurantId: args['restaurantId']!,
+                    heroTag: args['heroTag']!,
+                  ),
+                );
+              default:
+                return null;
+            }
+          },
+        );
       },
     );
   }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_foundation
 import sqflite_darwin
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   flutter_rating_bar: ^4.0.1
   readmore: ^3.0.0
 
+  # Local storage
+  shared_preferences: ^2.4.0
   sqflite: ^2.4.1
   sqflite_common_ffi_web: ^0.4.5+4
 


### PR DESCRIPTION
### Changes Made

This PR introduces a theme setting feature, allowing users to switch between light and dark modes based on their preference. Key changes include:

- Implemented system, light, and dark mode options.
- Updated UI to handle theme changes dynamically.
- Used SharedPreferences to persist the selected theme across sessions.
- Ensured dynamic theme changes throughout the app.

